### PR TITLE
feat: add Docker and Docker Compose support for all three LensMint services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Owner Portal
+VITE_PRIVY_APP_ID=your-privy-app-id
+VITE_BACKEND_URL=http://localhost:5000
+
+# Public Server
+FRONTEND_URL=http://localhost:3000
+CLAIM_SERVER_URL=http://localhost:4000
+
+# Hardware Web3 Service
+PRIVY_APP_ID=your-privy-app-id
+PRIVY_APP_SECRET=your-privy-app-secret
+PRIVATE_KEY=your-wallet-private-key
+RPC_URL=https://sepolia.infura.io/v3/your-infura-key
+DEVICE_REGISTRY_ADDRESS=your-contract-address
+LENSMINT_ERC1155_ADDRESS=your-contract-address
+LENSMINT_VERIFIER_ADDRESS=your-contract-address
+FILECOIN_API_KEY=your-filecoin-api-key
+WEB_PROVER_API_CLIENT_ID=your-vlayer-client-id
+WEB_PROVER_API_SECRET=your-vlayer-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+
+  owner-portal:
+    build:
+      context: ./owner-portal
+      dockerfile: Dockerfile
+    container_name: lensmint-owner-portal
+    ports:
+      - "3000:80"
+    environment:
+      - VITE_PRIVY_APP_ID=${VITE_PRIVY_APP_ID}
+      - VITE_BACKEND_URL=${VITE_BACKEND_URL:-http://localhost:5000}
+    depends_on:
+      - hardware-web3-service
+    networks:
+      - lensmint-network
+
+  public-server:
+    build:
+      context: ./lensmint-public-server
+      dockerfile: Dockerfile
+    container_name: lensmint-public-server
+    ports:
+      - "4000:4000"
+    environment:
+      - PORT=4000
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - CLAIM_SERVER_URL=${CLAIM_SERVER_URL:-http://localhost:4000}
+      - DATABASE_PATH=./database/claims.db
+    volumes:
+      - public-server-db:/app/database
+    networks:
+      - lensmint-network
+
+  hardware-web3-service:
+    build:
+      context: ./hardware-web3-service
+      dockerfile: Dockerfile
+    container_name: lensmint-web3-service
+    ports:
+      - "5000:5000"
+    environment:
+      - PORT=5000
+      - PRIVY_APP_ID=${PRIVY_APP_ID}
+      - PRIVY_APP_SECRET=${PRIVY_APP_SECRET}
+      - PRIVATE_KEY=${PRIVATE_KEY}
+      - RPC_URL=${RPC_URL}
+      - DEVICE_REGISTRY_ADDRESS=${DEVICE_REGISTRY_ADDRESS}
+      - LENSMINT_ERC1155_ADDRESS=${LENSMINT_ERC1155_ADDRESS}
+      - LENSMINT_VERIFIER_ADDRESS=${LENSMINT_VERIFIER_ADDRESS}
+      - FILECOIN_API_KEY=${FILECOIN_API_KEY}
+      - WEB_PROVER_API_CLIENT_ID=${WEB_PROVER_API_CLIENT_ID}
+      - WEB_PROVER_API_SECRET=${WEB_PROVER_API_SECRET}
+      - DATABASE_PATH=./database/lensmint.db
+    volumes:
+      - web3-service-db:/app/database
+    networks:
+      - lensmint-network
+
+networks:
+  lensmint-network:
+    driver: bridge
+
+volumes:
+  public-server-db:
+  web3-service-db:

--- a/hardware-web3-service/.dockerignore
+++ b/hardware-web3-service/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+database
+.env
+*.log

--- a/hardware-web3-service/Dockerfile
+++ b/hardware-web3-service/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install --production
+
+COPY . .
+
+RUN mkdir -p ./database
+
+EXPOSE 5000
+
+CMD ["node", "server.js"]

--- a/lensmint-public-server/.dockerignore
+++ b/lensmint-public-server/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+database
+.env
+*.log

--- a/lensmint-public-server/Dockerfile
+++ b/lensmint-public-server/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install --production
+
+COPY . .
+
+RUN mkdir -p ./database
+
+EXPOSE 4000
+
+CMD ["node", "server.js"]

--- a/owner-portal/.dockerignore
+++ b/owner-portal/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+*.log

--- a/owner-portal/Dockerfile
+++ b/owner-portal/Dockerfile
@@ -1,0 +1,23 @@
+# Build stage — compiles the Vite React app
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install --legacy-peer-deps
+
+COPY . .
+
+RUN npm run build
+
+# Production stage — serves static files via nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/owner-portal/nginx.conf
+++ b/owner-portal/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary

Adds full Docker and Docker Compose support across all three LensMint 
services, enabling any contributor to spin up the entire stack locally 
with a single command — no manual Node.js setup, no dependency conflicts, 
no environment guesswork.

## Motivation

Currently, setting up LensMint locally requires:
- Manually installing and configuring Node.js for three separate services
- Resolving peer dependency conflicts (as seen in issues like #31)
- Manually creating .env files with no clear reference for what's needed
- Starting each service in a separate terminal

This PR removes all of that friction and makes the project significantly 
more accessible to new contributors and GSoC applicants.

## Changes

### Owner Portal (`owner-portal/`)
- `Dockerfile` — multi-stage build: Node.js 18 Alpine for building the 
  Vite app, then nginx Alpine to serve the static output. Keeps the final 
  image small and production-appropriate.
- `nginx.conf` — configures nginx to support React client-side routing 
  (all routes fall back to index.html) with static asset caching.
- `.dockerignore` — excludes node_modules, dist, .env files and logs.

### Public Server (`lensmint-public-server/`)
- `Dockerfile` — Node.js 18 Alpine, installs production dependencies only, 
  creates the database directory, exposes port 4000.
- `.dockerignore` — excludes node_modules, database files and .env.

### Hardware Web3 Service (`hardware-web3-service/`)
- `Dockerfile` — Node.js 18 Alpine, installs production dependencies only,
  creates the database directory, exposes port 5000.
- `.dockerignore` — excludes node_modules, database files and .env.

### Root Level
- `docker-compose.yml` — orchestrates all three services on a shared 
  bridge network (`lensmint-network`). Database files are persisted via 
  named Docker volumes so data survives container restarts. All secrets 
  and config are passed via environment variables at runtime — nothing 
  baked into the image.
- `.env.example` — single root-level template covering every environment 
  variable needed across all three services, with clear comments.

## Architecture
```
docker compose up --build
        │
        ├── owner-portal        (port 3000) — nginx serving built React app
        ├── public-server       (port 4000) — Node.js claim/QR server
        └── hardware-web3-service (port 5000) — Node.js blockchain service
                │
                └── all connected via lensmint-network bridge
```

## Usage
```bash
# 1. Copy environment template
cp .env.example .env

# 2. Fill in your values in .env

# 3. Start everything
docker compose up --build

# Services:
# Owner Portal      → http://localhost:3000
# Public Server     → http://localhost:4000
# Web3 Service      → http://localhost:5000

# Stop everything
docker compose down

# Stop and delete volumes (clears database)
docker compose down -v
```

## Design Decisions

- **Multi-stage build for owner-portal**: The builder stage uses the full 
  Node.js image to compile the Vite app. The final stage uses nginx Alpine 
  (~25MB) instead of Node (~150MB), keeping the image lean.
- **Production deps only for backend services**: Both Node.js services use 
  `npm install --production` to exclude devDependencies from the image.
- **Named volumes for databases**: SQLite database files are stored in 
  named Docker volumes, not bind mounts, so they persist across 
  `docker compose down` and work cross-platform without permission issues.
- **No secrets in images**: All API keys, private keys and app secrets are 
  injected at runtime via environment variables. The .env file is excluded 
  from all images via .dockerignore.
- **Shared bridge network**: All services communicate over `lensmint-network` 
  rather than exposing inter-service calls through the host.

## Testing

- [ ] `docker compose build` completes without errors
- [ ] All three containers start with `docker compose up`
- [ ] Owner portal accessible at http://localhost:3000
- [ ] Public server accessible at http://localhost:4000
- [ ] Web3 service accessible at http://localhost:5000
- [ ] Containers communicate via lensmint-network
- [ ] Database persists after `docker compose down` and `docker compose up`